### PR TITLE
fix(semaphores): throw when using named semaphores on unix

### DIFF
--- a/JsonStores.Tests/Concurrent/Semaphores/NamedSemaphore.cs
+++ b/JsonStores.Tests/Concurrent/Semaphores/NamedSemaphore.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using JsonStores.Concurrent.SemaphoreFactories;
+using JsonStores.Tests.Helpers;
 using JsonStores.Tests.Models;
 using Xunit;
 
@@ -16,7 +17,7 @@ namespace JsonStores.Tests.Concurrent.Semaphores
             _semaphoreName = Guid.NewGuid().ToString();
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void SameFactory()
         {
             ISemaphoreFactory factory = new NamedSemaphoreFactory(_semaphoreName);
@@ -28,7 +29,7 @@ namespace JsonStores.Tests.Concurrent.Semaphores
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void DiffFactories()
         {
             using var expectedSemaphore = new Semaphore(1, 1, _semaphoreName);

--- a/JsonStores.Tests/Concurrent/Semaphores/PerFileSemaphore.cs
+++ b/JsonStores.Tests/Concurrent/Semaphores/PerFileSemaphore.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using JsonStores.Concurrent.SemaphoreFactories;
+using JsonStores.Tests.Helpers;
 using JsonStores.Tests.Models;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace JsonStores.Tests.Concurrent.Semaphores
             _factory = new PerFileSemaphoreFactory(_options);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void SameFactory()
         {
             var semaphore1 = _factory.GetSemaphore<Person>();
@@ -34,7 +35,7 @@ namespace JsonStores.Tests.Concurrent.Semaphores
         }
 
 
-        [Fact]
+        [WindowsOnlyFact]
         public void DiffFactory()
         {
             var semaphore1 = _factory.GetSemaphore<Person>();
@@ -51,7 +52,7 @@ namespace JsonStores.Tests.Concurrent.Semaphores
             Assert.True(released);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void DiffFiles()
         {
             var personSemaphore = _factory.GetSemaphore<Person>();

--- a/JsonStores.Tests/Helpers/WindowsOnlyFact.cs
+++ b/JsonStores.Tests/Helpers/WindowsOnlyFact.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.InteropServices;
+using Xunit;
+
+namespace JsonStores.Tests.Helpers
+{
+    public sealed class WindowsOnlyFact : FactAttribute
+    {
+        public WindowsOnlyFact()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Skip = "This test is only available on Windows.";
+        }
+    }
+}

--- a/JsonStores/Concurrent/SemaphoreFactories/NamedSemaphoreFactory.cs
+++ b/JsonStores/Concurrent/SemaphoreFactories/NamedSemaphoreFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace JsonStores.Concurrent.SemaphoreFactories
@@ -6,6 +7,7 @@ namespace JsonStores.Concurrent.SemaphoreFactories
     /// <summary>
     ///     Creates a named (system-wide) semaphore.
     /// </summary>
+    /// <remarks>This class is only available on Windows.</remarks>
     public class NamedSemaphoreFactory : ISemaphoreFactory
     {
         private readonly string _semaphoreName;
@@ -17,12 +19,16 @@ namespace JsonStores.Concurrent.SemaphoreFactories
         /// <param name="semaphoreName">The name to be used in the semaphore.</param>
         public NamedSemaphoreFactory(string semaphoreName)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                throw new PlatformNotSupportedException(
+                    $"'{nameof(NamedSemaphoreFactory)}' is only available on Windows.");
+
             _semaphoreName = semaphoreName;
         }
 
         /// <inheritdoc />
         /// <summary>
-        ///     Gets a singleton named semaphore instance. The <typeparamref name="T"/> param is ignored.
+        ///     Gets a singleton named semaphore instance. The <typeparamref name="T" /> param is ignored.
         /// </summary>
         public Semaphore GetSemaphore<T>()
         {

--- a/JsonStores/Concurrent/SemaphoreFactories/PerFileSemaphoreFactory.cs
+++ b/JsonStores/Concurrent/SemaphoreFactories/PerFileSemaphoreFactory.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace JsonStores.Concurrent.SemaphoreFactories
@@ -8,6 +10,7 @@ namespace JsonStores.Concurrent.SemaphoreFactories
     /// <summary>
     ///     Uses the file path to create a system-wide semaphore.
     /// </summary>
+    /// <remarks>This class is only available on Windows.</remarks>
     public class PerFileSemaphoreFactory : ISemaphoreFactory
     {
         private const string DefaultSemaphorePrefix = "cb96cc39-d2a6-4190-9119-7aaaebfa4443";
@@ -19,28 +22,33 @@ namespace JsonStores.Concurrent.SemaphoreFactories
         /// <summary>
         ///     Creates a new instance using the default semaphore name prefix and default options.
         /// </summary>
-        /// <seealso cref="JsonStoreOptions"/>
+        /// <seealso cref="JsonStoreOptions" />
         public PerFileSemaphoreFactory() : this(new JsonStoreOptions())
         {
+            ThrowIfIsNotWindows();
         }
 
         /// <summary>
-        ///     Creates a new instance using the default semaphore name prefix and the specified <see cref="JsonStoreOptions"/>.
+        ///     Creates a new instance using the default semaphore name prefix and the specified <see cref="JsonStoreOptions" />.
         /// </summary>
         /// <param name="options">The options used to retrieve the file name.</param>
         public PerFileSemaphoreFactory(JsonStoreOptions options)
         {
+            ThrowIfIsNotWindows();
+
             _options = options;
             _semaphorePrefix = DefaultSemaphorePrefix;
         }
 
         /// <summary>
-        ///     Creates a new instance specifying the options and the prefix to be used on named semaphores. 
+        ///     Creates a new instance specifying the options and the prefix to be used on named semaphores.
         /// </summary>
         /// <param name="options">The options used to retrieve the file name.</param>
         /// <param name="semaphorePrefix">The prefix to be used on named semaphores.</param>
         public PerFileSemaphoreFactory(JsonStoreOptions options, string semaphorePrefix)
         {
+            ThrowIfIsNotWindows();
+
             _options = options;
             _semaphorePrefix = semaphorePrefix;
         }
@@ -67,6 +75,13 @@ namespace JsonStores.Concurrent.SemaphoreFactories
 
             foreach (var semaphore in _semaphores.Values)
                 semaphore.Dispose();
+        }
+
+        private static void ThrowIfIsNotWindows()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                throw new PlatformNotSupportedException(
+                    $"'{nameof(PerFileSemaphoreFactory)}' is only available on Windows.");
         }
     }
 }

--- a/JsonStores/JsonStores.csproj
+++ b/JsonStores/JsonStores.csproj
@@ -9,7 +9,7 @@
         <Title>JsonStores</Title>
         <Description>Persist your data on JSON files in an easy and flexible way</Description>
         <PackageId>JsonStores</PackageId>
-        <Version>0.4.0</Version>
+        <Version>0.4.1</Version>
         <PackageReleaseNotes>Thread-safe stores</PackageReleaseNotes>
         <Authors>Augusto César Bisognin</Authors>
         <PackageTags>json repository store</PackageTags>

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ There are three built-in implementations:
   entire SO.
 - `PerFileSemaphoreFactory` returns a named semaphore based on a given `IJsonStoreOptions`.
 
+> Named semaphores are only available on Windows machines. See [this issue](https://github.com/dotnet/runtime/issues/4370) for details.
+
 #### Custom factory
 
 To implement your own factory, just return a binary (from 1 to 1) Semaphore object.


### PR DESCRIPTION
Named semaphores are not available on Unix systems, so a
PlatformNotSupported exception is throw